### PR TITLE
remove timeouts b/c promise error

### DIFF
--- a/src/saga/create.js
+++ b/src/saga/create.js
@@ -142,7 +142,7 @@ export async function replaceFromBase64(context, fileContents) {
 }
 
 export async function runReplaceFromBase64(fileContents) {
-  runOperationNoSync(replaceFromBase64, fileContents);
+  await runOperationNoSync(replaceFromBase64, fileContents);
 }
 
 async function createFromURL(context, url, email) {

--- a/src/saga/upgrade.js
+++ b/src/saga/upgrade.js
@@ -1,7 +1,7 @@
 import { runOperation } from "./runOperation";
 import { TEST_URL } from "../constants";
 import * as scenarios from "../../scenarios";
-import { replaceFromBase64 } from "./create";
+import { runReplaceFromBase64 } from "./create";
 import { getFileContents } from "./fileUtils";
 import Project from "./Project";
 /*
@@ -43,9 +43,7 @@ export async function upgradeAllScenarios() {
         const scenarioJSON = scenarios[scenarioName];
 
         // First, we load the scenario
-        await runOperation(replaceFromBase64, scenarioJSON.fileContents);
-
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        await runReplaceFromBase64(scenarioJSON.fileContents);
 
         // Then, we run the upgrade function 
         let upgraded = false;

--- a/src/tests/suites/catchUpTests.js
+++ b/src/tests/suites/catchUpTests.js
@@ -36,10 +36,8 @@ export async function testResetPersonalChangesLastCaughtUp() {
 
     // Load scenario
     const fileContents = scenarios["unmergedNoConflict"].fileContents;
-    await runReplaceFromBase64(fileContents)
+    await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000))
 
     // Then, we check that the last catch up is the first commit.
     let originalLastCatchUp;

--- a/src/tests/suites/diffTests.js
+++ b/src/tests/suites/diffTests.js
@@ -9,9 +9,6 @@ export async function testDiffSimple() {
     const fileContents = scenarios["diffSimple"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Perform a merge
     const g = getGlobal();
     const catchUpResult = await g.catchUp();
@@ -38,9 +35,6 @@ export async function acrossSheetsDiff() {
     const fileContents = scenarios["acrossSheetsDiff"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Then, we get the diffs
     const g = getGlobal();
     const newDiffs = await g.catchUp();
@@ -59,9 +53,6 @@ export async function testNoDiffAfterMerge() {
     // Load scenario
     const fileContents = scenarios["unmergedNoConflict"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Perform a merge
     const g = getGlobal();
@@ -82,9 +73,6 @@ export async function testDiffMedium() {
     // Load scenario
     const fileContents = scenarios["diffMedium"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Perform a merge
     const g = getGlobal();

--- a/src/tests/suites/mergeConflictsTests.js
+++ b/src/tests/suites/mergeConflictsTests.js
@@ -13,9 +13,6 @@ export async function testOriginalEmptyMergeConflict() {
     const fileContents = scenarios["mergeConflictSimpleEmptyOrigin"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Perform a merge
     const g = getGlobal();
     const mergeResult = await g.merge();
@@ -51,9 +48,6 @@ export async function testAddingColumnMergeConflict() {
     const fileContents = scenarios["addingColumnUnmerged"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Perform a merge
     const g = getGlobal();
     const mergeResult = await g.merge();
@@ -71,9 +65,6 @@ export async function testMergeConflict() {
     // Load scenario
     const fileContents = scenarios["twoPageUnmergedConflict"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Perform a merge
     const g = getGlobal();
@@ -126,9 +117,6 @@ export async function testMultipleConflictsPerSheet() {
     // Load scenario
     const fileContents = scenarios["multipleMergeConflictsPerSheet"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Perform a merge
     const g = getGlobal();

--- a/src/tests/suites/mergeFormattingTests.js
+++ b/src/tests/suites/mergeFormattingTests.js
@@ -4,6 +4,7 @@ import { getGlobal } from "../../commands/commands";
 import * as scenarios from "../../../scenarios";
 import { mergeState } from "../../constants";
 
+/* global Excel */
 
 
 export async function testMergeBold() {
@@ -11,10 +12,6 @@ export async function testMergeBold() {
     // Load scenario
     const fileContents = scenarios["diffSimple"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
 
     // Bold A1
     await Excel.run(async function (context) {
@@ -58,9 +55,6 @@ export async function testMergeMultipleBolds() {
     // Load scenario
     const fileContents = scenarios["diffSimple"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
     
 
     // Bold A1:B3
@@ -106,9 +100,6 @@ export async function testMultiPageBold() {
     // Load scenario
     const fileContents = scenarios["diffSimple"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Bold A1 in both sheets
     // Bold A1:B3
@@ -168,9 +159,6 @@ export async function testMergeKeepsFromattingInMaster() {
     // Load scenario
     const fileContents = scenarios["formattingInMaster"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Bold B1
     await Excel.run(async function (context) {

--- a/src/tests/suites/mergeSheetChangeTests.js
+++ b/src/tests/suites/mergeSheetChangeTests.js
@@ -13,9 +13,6 @@ export async function testMergeDeleteSheet() {
     const fileContents = scenarios["unmergedLocalSheetDelete"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     const g = getGlobal();
     await g.merge();
 

--- a/src/tests/suites/mergeTests.js
+++ b/src/tests/suites/mergeTests.js
@@ -102,9 +102,6 @@ export async function testMergeChangesLastCaughtUp() {
     const fileContents = scenarios["unmergedNoConflict"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Then, we check that the last catch up is the first commit.
     let originalLastCatchUp;
     await runOperation(async (context) => {
@@ -135,9 +132,6 @@ export async function testNoDiffAfterMerge() {
     // Load scenario
     const fileContents = scenarios["unmergedNoConflict"].fileContents;
     await runReplaceFromBase64(fileContents);
-
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
 
     // Catch up
     const g = getGlobal();

--- a/src/tests/suites/resetPersonalTests.js
+++ b/src/tests/suites/resetPersonalTests.js
@@ -13,9 +13,6 @@ export async function testResetPersonal() {
     const fileContents = scenarios["unmergedConflict"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Switch to master version
     const g = getGlobal();
     await g.resetPersonalVersion();

--- a/src/tests/suites/switchVersionTests.js
+++ b/src/tests/suites/switchVersionTests.js
@@ -39,9 +39,6 @@ export async function testSwitchVersionsDoesNotDeletePersonal() {
     const fileContents = scenarios["switchVersionDoesNotDeletePersonal"].fileContents;
     await runReplaceFromBase64(fileContents);
 
-    // Give time for files to update properly 
-    await new Promise(resolve => setTimeout(resolve, 2000));
-
     // Switch to master version
     const g = getGlobal();
     await g.switchVersion();


### PR DESCRIPTION
# Changes

Addresses #25. We were just missing an `await` in the `runReplaceFromBase64` function, which was causing a promise to not be waited on.

This also has the benefit of cutting like a minute from the tests!

- [x] I ran all the tests to make sure I didn't break anything.